### PR TITLE
Add -c|--limit-creds option to autopwn.

### DIFF
--- a/flag_slurper/autolib/exploit.py
+++ b/flag_slurper/autolib/exploit.py
@@ -7,6 +7,7 @@ import os
 import paramiko
 
 FlagConf = Dict[str, Any]
+LimitCreds = Optional[List[str]]
 SUDO_OPT = Optional[str]
 logger = logging.getLogger(__name__)
 

--- a/flag_slurper/autolib/models.py
+++ b/flag_slurper/autolib/models.py
@@ -25,9 +25,6 @@ class CredentialBag(BaseModel):
     def __str__(self):
         return "{}:{}".format(self.username, self.password)
 
-    def __repr__(self):
-        return "<CredentialBag {}>".format(self.__str__())
-
 
 class Team(BaseModel):
     id = peewee.IntegerField(primary_key=True)
@@ -65,9 +62,6 @@ class Credential(BaseModel):
             flags += SUDO_FLAG
 
         return "{}:{}{}".format(self.bag.username, self.bag.password, flags)
-
-    def __repr__(self):
-        return "<Credential {}>".format(self.__str__())
 
 
 class Flag(BaseModel):

--- a/flag_slurper/autolib/protocols.py
+++ b/flag_slurper/autolib/protocols.py
@@ -4,11 +4,11 @@ from typing import Tuple
 
 import paramiko
 
-from flag_slurper.autolib.exploit import get_file_contents, get_system_info, LimitCreds
-from flag_slurper.autolib.governor import Governor
-from .exploit import find_flags, FlagConf, can_sudo
-from .models import Service, CredentialBag, Credential, Flag, CaptureNote
+from .exploit import find_flags, FlagConf, can_sudo, get_file_contents, get_system_info, LimitCreds
+from .governor import Governor
+from .models import Service, Credential, Flag, CaptureNote
 from .post import post_ssh
+from .utils import limited_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +26,7 @@ def pwn_ssh(url: str, port: int, service: Service, flag_conf: FlagConf,
     enable_search = flag_conf['search'] if flag_conf else True
 
     working = set()
-    credentials = CredentialBag.select()
-
-    if limit_creds:
-        credentials = credentials.where(CredentialBag.username.in_(limit_creds))
-
+    credentials = limited_credentials(limit_creds)
     for credential in credentials:
         # Govern if necessary (and enabled)
         gov = Governor.get_instance()

--- a/flag_slurper/autolib/service.py
+++ b/flag_slurper/autolib/service.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, Any, Optional
+from typing import Tuple, Dict, Any, Optional, List
 
 from .exploit import FlagConf
 from .models import Service
@@ -51,10 +51,10 @@ def detect_service(service: Service) -> Tuple[str, int, str]:
     return SERVICE_MAP[service.service_port], service.service_url, service.service_port
 
 
-def pwn_service(service: Service, flag_conf: Optional[FlagConf]) -> Result:
+def pwn_service(service: Service, flag_conf: Optional[FlagConf], limit_creds: Optional[List[str]]) -> Result:
     proto, url, port = detect_service(service)
     if proto not in PWN_FUNCS:
         return Result(service=service, message="Protocol not supported for autopwn", success=False, skipped=True)
 
-    message, success, skipped = PWN_FUNCS[proto](url, port, service, flag_conf)
+    message, success, skipped = PWN_FUNCS[proto](url, port, service, flag_conf, limit_creds)
     return Result(service=service, message=message, success=success, skipped=skipped)

--- a/flag_slurper/autolib/utils.py
+++ b/flag_slurper/autolib/utils.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from .exploit import LimitCreds
+from .models import CredentialBag
+
+
+def limited_credentials(limit: LimitCreds) -> List[CredentialBag]:
+    """
+    Filter the credentials bags by the given usernames.
+
+    :param limit: The usernames to filter
+    :return: The filtered list of credential bags
+    """
+    creds = CredentialBag.select()
+    if not limit:
+        return creds
+    return creds.where(CredentialBag.username.in_(limit))

--- a/tests/autolib/test_models.py
+++ b/tests/autolib/test_models.py
@@ -11,7 +11,7 @@ def test_cred_bag__str__(bag):
 
 
 def test_cred_bag__repr__(bag):
-    assert bag.__repr__() == "<CredentialBag root:cdc>"
+    assert bag.__repr__() == "<CredentialBag: root:cdc>"
 
 
 def test_cred__str__(credential):
@@ -19,7 +19,7 @@ def test_cred__str__(credential):
 
 
 def test_cred__repr__(credential):
-    assert credential.__repr__() == "<Credential root:cdc>"
+    assert credential.__repr__() == "<Credential: root:cdc>"
 
 
 def test_cred_sudo__str__(sudocred):
@@ -27,7 +27,7 @@ def test_cred_sudo__str__(sudocred):
 
 
 def test_cred_sudo__repr__(sudocred):
-    assert sudocred.__repr__() == "<Credential cdc:cdc{}>".format(SUDO_FLAG)
+    assert sudocred.__repr__() == "<Credential: cdc:cdc{}>".format(SUDO_FLAG)
 
 
 def test_capture_note__str__(flag, service):

--- a/tests/autolib/test_service.py
+++ b/tests/autolib/test_service.py
@@ -46,7 +46,7 @@ def test_detect_unknown_service(invalid_service):
 
 
 def test_pwn_invalid_service(invalid_service):
-    res = pwn_service(invalid_service, None)
+    res = pwn_service(invalid_service, None, None)
     assert not res.success
     assert res.skipped
     assert res.message == "Protocol not supported for autopwn"
@@ -57,7 +57,7 @@ def test_pwn_service(service, mocker):
     pwn_http.return_value = "service up", True, False
 
     PWN_FUNCS['http'] = pwn_http
-    res = pwn_service(service, None)
+    res = pwn_service(service, None, None)
 
     result = Result(service, "service up", success=True, skipped=False)
     assert result == res

--- a/tests/autolib/test_utils.py
+++ b/tests/autolib/test_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+from flag_slurper.autolib.utils import limited_credentials
+
+
+@pytest.fixture
+def bags(bag, sudobag):
+    bag.save()
+    sudobag.save()
+    yield [bag, sudobag]
+    bag.delete().execute()
+    sudobag.delete().execute()
+
+
+def test_limit_root(bags):
+    creds = limited_credentials(['root'])
+    assert len(creds) == 1
+    assert creds[0] == bags[0]
+
+
+def test_no_limit(bags):
+    creds = limited_credentials(None)
+    assert len(creds) == 2
+
+
+def test_excessive_limit(bags):
+    creds = limited_credentials(['a'])
+    assert len(creds) == 0


### PR DESCRIPTION
The command filters all credentials without the given username(s). The
option may be repeated as much as needed.