### PR TITLE
Reconcile team list and update to IScorE API

### DIFF
--- a/flag_slurper/autolib/models.py
+++ b/flag_slurper/autolib/models.py
@@ -110,11 +110,14 @@ def create():  # pragma: no cover
 
 
 def delete():  # pragma: no cover
-    CredentialBag.delete().execute()
-    Team.delete().execute()
-    Service.delete().execute()
-    Credential.delete().execute()
-    Flag.delete().execute()
-    CaptureNote.delete().execute()
-    File.delete().execute()
-    DNSResult.delete().execute()
+    def _del_instance(x):
+        x.delete_instance().execute()
+
+    list(map(_del_instance, CredentialBag.select()))
+    list(map(_del_instance, Team.select()))
+    list(map(_del_instance, Service.select()))
+    list(map(_del_instance, Credential.select()))
+    list(map(_del_instance, Flag.select()))
+    list(map(_del_instance, CaptureNote.select()))
+    list(map(_del_instance, File.select()))
+    list(map(_del_instance, DNSResult.select()))

--- a/flag_slurper/utils.py
+++ b/flag_slurper/utils.py
@@ -68,7 +68,7 @@ def save_flags(flags, team=None, base_path=None):
     z.close()
 
 
-def get_teams():
+def get_teams() -> list:
     conf = Config.get_instance()
     url = '{}/teams.json'.format(conf.api_url)
 
@@ -84,14 +84,40 @@ def get_team_map(teams):
 
 
 # TODO: Should be using the /services.json endpoint but it's currently 500'ing
-def get_service_status():
+def get_service_status() -> list:
     conf = Config.get_instance()
     url = '{}/servicestatus.json'.format(conf.api_url)
 
     resp = requests.get(url)
     resp.raise_for_status()
-    resp = resp.json()
-    return resp
+    return resp.json()
+
+
+def get_services() -> list:
+    conf = Config.get_instance()
+    url = '{}/services.json'.format(conf.api_url)
+
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_service(name) -> dict:
+    """
+    Get a service by its name.
+
+    .. note::
+
+        The IScorE API changed and the service_id returned by service status
+        cannot be used to find the service. As a temporary workaround, we are
+        matching on service name, which ***should*** be unique.
+
+    :param name: The name of the service
+    :return: The matched service.
+    """
+    if not hasattr(get_service, 'service_cache'):
+        get_service.service_cache = {s['name']: s for s in get_services()}
+    return get_service.service_cache[name]
 
 
 def report_error(msg):


### PR DESCRIPTION
When generating team/service list from IScorE, remove any teams that are in the local db, but not IScorE. This also updates `autopwn generate` to use the latest service and service status API. There has been a change to the data that requires using the service endpoint, rather than just the service status endpoint.