### PR TITLE
Limit AutoPWN by team, service name, or both.

### DIFF
--- a/flag_slurper/autopwn.py
+++ b/flag_slurper/autopwn.py
@@ -61,7 +61,8 @@ def _print_result(result, verbose):
 @click.option('-N', '--processes', type=click.INT, default=None, help="How manny process to use for async AutoPWN")
 @click.option('-c', '--limit-creds', type=click.STRING, multiple=True, help="Limit the attack to the given creds")
 @click.option('-t', '--team', type=click.INT, default=None, help="Limit the attack to the given team")
-def pwn(verbose, parallel, processes, limit_creds, team):
+@click.option('-s', '--service', type=click.STRING, default=None, help="Limit the attack to the given service name")
+def pwn(verbose, parallel, processes, limit_creds, team, service):
     utils.report_status("Starting AutoPWN")
     p = Project.get_instance()
 
@@ -76,6 +77,10 @@ def pwn(verbose, parallel, processes, limit_creds, team):
     if team:
         utils.report_status('Limited to team {}'.format(team))
         services = services.join(models.Team).where(models.Team.number == team)
+
+    if service:
+        utils.report_status('Limited to service {}'.format(service))
+        services = services.where(models.Service.service_name == service)
 
     if parallel:
         print("Using pool size: {}".format(processes))

--- a/tests/test_autopwn.py
+++ b/tests/test_autopwn.py
@@ -1,0 +1,26 @@
+import pytest
+from click.testing import CliRunner
+
+from flag_slurper.cli import cli
+from flag_slurper.project import Project
+
+
+@pytest.fixture
+def pwn_project(create_project):
+    tmpdir = create_project("""
+    _version: "1.0"
+    project: Flag Slurper Test
+    base: {dir}/pwn-test
+    """)
+    p = Project.get_instance()
+    p.load(str(tmpdir.join('project.yml')))
+    return str(tmpdir.join('project.yml'))
+
+
+def test_autopwn_no_project():
+    p = Project.get_instance()
+    p.project_data = None
+    runner = CliRunner()
+    result = runner.invoke(cli, ['-np', 'autopwn', 'results'])
+    assert result.exit_code == 4
+    assert result.output == "[!] AutoPWN commands require an active project\n"

--- a/tests/test_autopwn.py
+++ b/tests/test_autopwn.py
@@ -24,3 +24,19 @@ def test_autopwn_no_project():
     result = runner.invoke(cli, ['-np', 'autopwn', 'results'])
     assert result.exit_code == 4
     assert result.output == "[!] AutoPWN commands require an active project\n"
+
+
+def test_autopwn_pwn_limit_team(pwn_project, mocker, service):
+    runner = CliRunner()
+    pwn_service = mocker.patch('flag_slurper.autopwn._pwn_service')
+    result = runner.invoke(cli, ['autopwn', 'pwn', '-t', service.team.number])
+    assert result.exit_code == 0
+    pwn_service.assert_called_with((), service)
+
+
+def test_autopwn_pwn_limit_service(pwn_project, mocker):
+    runner = CliRunner()
+    pwn_service = mocker.patch('flag_slurper.autopwn._pwn_service')
+    result = runner.invoke(cli, ['autopwn', 'pwn', '-s', 'non-existant service'])
+    assert result.exit_code == 0
+    pwn_service.assert_not_called()


### PR DESCRIPTION
This adds the following flags to `autopwn pwn`: `-t,--team` to specify the team number to limit by, and `-s,--service` to specify the service name to limit by. They are not mutually exclusive.

Closes #43 