### PR TITLE
Add profile and shell configs to sensitive files

### DIFF
--- a/flag_slurper/autolib/post.py
+++ b/flag_slurper/autolib/post.py
@@ -48,6 +48,13 @@ SENSITIVE_FILES = [
     '/etc/cron.hourly/',
     '/etc/cron.monthly/',
     '/etc/cron.weekly/',
+
+    # Shell configs and profiles
+    '/etc/skel/',
+    '/etc/**/.bashrc',
+    '/etc/**/.bash_profile',
+    '/etc/**/.zshrc',
+    '/etc/**/.profile'
 ]
 
 

--- a/tests/response_mocks.py
+++ b/tests/response_mocks.py
@@ -44,3 +44,14 @@ ADMIN_FLAGS = [
         'data': 'FGHIJ',
     },
 ]
+
+BLUE_USER = {
+    'username': 'blueuser',
+    'first_name': 'Blue',
+    'last_name': 'User',
+    'is_superuser': False,
+    'profile': {
+        'is_red': False,
+        'is_blue': True,
+    }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,12 +49,14 @@ def test_cli_pass_config():
     runner.invoke(cli, ['cmd'])
 
 
+@responses.activate
 def test_plant_invalid_user(mocker):
     prompt = mocker.patch('flag_slurper.config.prompt')
     prompt.return_value = "ABC"
+    responses.add(responses.GET, 'https://iscore.iseage.org/api/v1/user/show.json', status=200, json=rm.BLUE_USER)
     runner = CliRunner()
     result = runner.invoke(cli, ['plant'])
-    assert result.exit_code == 1
+    assert result.exit_code == 2
 
 
 @responses.activate


### PR DESCRIPTION
Add the various `.bashrc` and `.profile` files to ssh exfil. Also grab the skel versions.

Closes #44 