### PR TITLE
Fix service list referring to teams by id rather than number.

### DIFF
--- a/flag_slurper/cli.py
+++ b/flag_slurper/cli.py
@@ -118,7 +118,7 @@ from .credentials import creds
 from .dns import dns
 from .project import project
 from .teams import team
-from .services import service
+from .services import services
 from .files import files
 from .notes import notes
 cli.add_command(config)
@@ -126,7 +126,7 @@ cli.add_command(creds)
 cli.add_command(dns)
 cli.add_command(project)
 cli.add_command(team)
-cli.add_command(service)
+cli.add_command(services)
 cli.add_command(files)
 cli.add_command(notes)
 

--- a/flag_slurper/services.py
+++ b/flag_slurper/services.py
@@ -8,7 +8,7 @@ from flag_slurper.conf.project import Project
 
 @click.group()
 @click.pass_context
-def service(ctx):
+def services(ctx):
     """
     Manage services.
     """
@@ -20,7 +20,7 @@ def service(ctx):
     ctx.obj = p
 
 
-@service.command()
+@services.command()
 @click.option('-t', '--team', default=None)
 def ls(team):
     """
@@ -29,7 +29,7 @@ def ls(team):
     query = Service.select(Service.id, Team.number, Service.service_name, Service.service_port, Service.service_url,
                            Service.is_rand, Service.high_target, Service.low_target).join(Team)
     if team:
-        query = query.where(Service.team == team)
+        query = query.where(Service.team.number == team)
 
     services = [
         [s.id, s.team.number, s.service_name, s.service_port, s.service_url, s.is_rand, s.high_target, s.low_target] for
@@ -39,7 +39,7 @@ def ls(team):
     utils.conditional_page(table.table, len(services))
 
 
-@service.command()
+@services.command()
 @click.argument('id')
 @click.argument('name')
 @click.option('-p', '--port', required=True)
@@ -56,7 +56,7 @@ def add(id, name, port, url, admin, is_rand, high, low, team):
         click.secho('Service added.', fg='green')
 
 
-@service.command()
+@services.command()
 @click.argument('id')
 def rm(id):
     with database_proxy.obj:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,48 @@
+import pytest
+from click.testing import CliRunner
+
+from flag_slurper.autolib.models import Service
+from flag_slurper.cli import cli
+from flag_slurper.conf.project import Project
+
+
+@pytest.fixture
+def services_project(create_project):
+    tmpdir = create_project("""
+    _version: "1.0"
+    project: Flag Slurper Test
+    base: {dir}/flag-test
+    """)
+    p = Project.get_instance()
+    p.load(str(tmpdir.join('project.yml')))
+    return str(tmpdir.join('project.yml'))
+
+
+def test_services_no_project():
+    p = Project.get_instance()
+    p.project_data = None
+    runner = CliRunner()
+    result = runner.invoke(cli, ['-np', 'services', 'ls'])
+    assert result.exit_code == 4
+    assert result.output == '[!] service commands require an active project\n'
+
+
+def test_list_services(service, services_project):
+    runner = CliRunner()
+    result = runner.invoke(cli, ['-p', services_project, 'services', 'ls'])
+    assert result.exit_code == 0
+    assert service.service_name in result.output
+
+
+def test_list_service_team(service, services_project):
+    runner = CliRunner()
+    result = runner.invoke(cli, ['-p', services_project, 'services', 'ls', '-t', service.team.number])
+    assert result.exit_code == 0
+    assert service.service_name in result.output
+
+
+def test_list_service_excluded_team(service, services_project):
+    runner = CliRunner()
+    result = runner.invoke(cli, ['-p', services_project, 'services', 'ls', '-t', '3'])
+    assert result.exit_code == 0
+    assert service.service_name not in result.output

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -50,6 +50,7 @@ def test_list_service_excluded_team(service, services_project):
 
 def test_rm_service(service, services_project):
     runner = CliRunner()
-    result = runner.invoke(cli, ['-p', services_project, 'services', 'rm', service.id])
+    result = runner.invoke(cli, ['-p', services_project, 'services', 'rm', str(service.id)])
     assert result.exit_code == 0
-    assert Service.select().where(Service.id == service.id).count()
+    assert 'Service removed.' in result.output
+    assert Service.select().where(Service.id == service.id).count() == 0

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -46,3 +46,10 @@ def test_list_service_excluded_team(service, services_project):
     result = runner.invoke(cli, ['-p', services_project, 'services', 'ls', '-t', '3'])
     assert result.exit_code == 0
     assert service.service_name not in result.output
+
+
+def test_rm_service(service, services_project):
+    runner = CliRunner()
+    result = runner.invoke(cli, ['-p', services_project, 'services', 'rm', service.id])
+    assert result.exit_code == 0
+    assert Service.select().where(Service.id == service.id).count()


### PR DESCRIPTION
Also rename service command to be plural like the rest of them.

Closes #77.