### PR TITLE
Fix recording capture credentials when using sudo

### DIFF
--- a/flag_slurper/autolib/protocols.py
+++ b/flag_slurper/autolib/protocols.py
@@ -80,7 +80,7 @@ def pwn_ssh(url: str, port: int, service: Service, flag_conf: FlagConf,
                         if flag:
                             enable_search = False
                             CaptureNote.get_or_create(flag=flag_obj, data=flag, location=full_location,
-                                                      notes=str(sysinfo), service=service, used_creds=sudo_cred)
+                                                      notes=str(sysinfo), service=service, used_creds=cred)
 
                     if enable_search:
                         local_flags = find_flags(ssh, base_dir=base_dir)


### PR DESCRIPTION
`used_creds` needs to be a reference, not a value. Oops.

Closes #82 